### PR TITLE
Format flet output

### DIFF
--- a/assets/email_template.html
+++ b/assets/email_template.html
@@ -79,26 +79,30 @@
     <div class="header">
       <h1>Google Cloud Newsletter</h1>
     </div>
+    {% for i, date in dates %}
+    <h2>{{ formatted_dates[i] }}</h2>
+    <div>
+      <h3>Recommended Articles</h3>
+      <p>{{ recommended_articles[date].summary_text }}</p>
+      {% for article in recommended_articles[date][user_persona_topic].recommendations %}
+      <div class="articles">
+        <div class="article">
+          <h4>{{ article.recommendation_title }}</h4>
+          <p>{{ article.recommendation_summary }}</p>
+          <p>{{ article.recommendation_reason }}</p>
+          <a href="{{ article.recommendation_link }}" class="button">Read More</a>
+          </div>
+          {% endfor %}
+          </div>
 
-    <h2>Recommended Articles</h2>
-    <p>{{ recommended_articles.summary_text }}</p>
-    <div class="articles">
-      {% for article in recommended_articles.recommendations %}
-      <div class="article">
-        <h3>{{ article.recommendation_title }}</h3>
-        <p>{{ article.recommendation_summary }}</p>
-        <p>{{ article.recommendation_reason }}</p>
-        <a href="{{ article.recommendation_link }}" class="button">Read More</a>
-      </div>
-      {% endfor %}
-    </div>
-
-    <h2>All Articles</h2>
-    <div class="articles">
-      {% for article in all_articles %}
-      <h3><a href="{{ article.link }}">{{ article.title }}</a></h3>
-      <p>{{ article.summary }}</p>
-      {% endfor %}
+      <h3>All Articles</h3>
+      <div class="articles">
+        {% for article in all_articles[date].summaries %}
+        <h4><a href="{{ article.link }}">{{ article.title }}</a></h4>
+        <p>{{ article.summary }}</p>
+        {% endfor %}
+        </div>
+        {% endfor %}
     </div>
 
     <div class="footer">

--- a/db_service.py
+++ b/db_service.py
@@ -31,20 +31,23 @@ def write_to_firestore(collection, data):
     return doc_ref.id
 
 def get_components_from_firestore(collection, document_id):
-    """Retrieves a document from a Firestore collection.
+    """Retrieves a single document from a Firestore collection.
 
     Args:
         collection (str): The name of the Firestore collection.
         document_id (str): The ID of the document to retrieve.
 
     Returns:
-        dict: The document data as a dictionary, or None if the document is not found.
+        dict: The document as a dictionary (including the document_id as key), or None if the document is not found.
+              Format example: {"document_id":document_contents}
     """
     try:
+        d_doc = {}
         doc_ref = db.collection(collection).document(document_id)
         doc = doc_ref.get()
         if doc.exists:
-            return doc.to_dict()
+            d_doc[document_id] = doc.to_dict()
+            return d_doc
         else:
             print(f"No newsletter found for {document_id}")
             return None
@@ -52,30 +55,33 @@ def get_components_from_firestore(collection, document_id):
         print(f"Error retrieving newsletter from Firestore: {e}")
         return None
 
-def get_documents_for_past_week(collection):
-    """Retrieves documents for the past seven days from a Firestore collection.
+
+def get_documents_for_past_n_days(collection, n=7):
+    """Retrieves documents for the past N days from a Firestore collection.
 
     Args:
         collection (str): The name of the Firestore collection.
+        n (int): Number of days to go back in time. Defaults to 7 (a week).
 
     Returns:
-        list: A list of dictionaries, where each dictionary represents a document. Returns an empty list if no documents are found or an error occurs.
+        n_docs (dict): A dictionary with document_id as key values and document (converted to dicts) as values.
+            Returns empty dict for exeptions.
     """
 
     try:
         today = datetime.date.today()
-        week_docs = []
-        for i in range(7):  # Iterate through the past 7 days
+        n_docs = {}
+        for i in range(n):  # Iterate through the past N days
             past_date = today - datetime.timedelta(days=i)
             date_str = past_date.strftime("%m_%d_%Y")  # Format the date string
             doc_ref = db.collection(collection).document(date_str)
             doc = doc_ref.get()
             if doc.exists:
-                week_docs.append(doc.to_dict())
-        return week_docs
+                n_docs[date_str] = doc.to_dict()
+        return n_docs
     except Exception as e:
         print(f"Error retrieving past week's documents: {e}")
-        return []
+        return {}
 
 def search_firestore_by_field(collection_name, field_name, field_value):
     """Searches Firestore for documents matching a specific field value.

--- a/main.py
+++ b/main.py
@@ -1,9 +1,12 @@
 import flet as ft
+import tempfile
 import os
 import newsletter_service, db_service
 
-USER_PERSONA = db_service.get_components_from_firestore('gcp_newsletter', 'settings')['persona']
-USER_TOPIC = db_service.get_components_from_firestore('gcp_newsletter', 'settings')['topic']
+USER_PERSONA = db_service.get_components_from_firestore(
+    'gcp_newsletter', 'settings')['settings']['persona']
+USER_TOPIC = db_service.get_components_from_firestore(
+    'gcp_newsletter', 'settings')['settings']['topic']
 TIME_PERIOD = ["day", "week"]
 
 # Define the RSS feed URL - "https://blog.google/products/google-cloud/rss/"
@@ -29,18 +32,26 @@ def main(page: ft.Page):
             user_topic=topic.value,
         )
         # Return Newsletter Content to Display on Webpage.
-        newsletter_container = ft.Container(
-            content=ft.Column(
-                [
-                    ft.Text(value=newsletter),
-                ],
-                scroll=ft.ScrollMode.AUTO,  # Enable scrolling
-                expand=True,  # Allow the container to expand to fit content
-            ),
-            expand=True,  # Allow the container to take up available space
-        )
-        
-        page.add(newsletter_container)  # Add the container to the page
+        # newsletter_container = ft.Container(
+        #     content=ft.Column(
+        #         [
+        #             ft.Text(value=newsletter),
+        #         ],
+        #         scroll=ft.ScrollMode.AUTO,  # Enable scrolling
+        #         expand=True,  # Allow the container to expand to fit content
+        #     ),
+        #     expand=True,  # Allow the container to take up available space
+        # )
+        # Create html formatted email
+        with tempfile.NamedTemporaryFile(mode="w",
+                                         delete=False,
+                                         dir="/tmp",
+                                         suffix=".html") as f:
+            f.write(newsletter)
+            temp_file_path = f.name
+        file_url = f"file://{temp_file_path}"
+        page.launch_url(url=file_url)
+        # page.add(newsletter_container)  # Add the container to the page
         page.update()
 
     p = ft.Text()


### PR DESCRIPTION
Previous flow: user clicks generate and a poorly formatted newsletter gets populated in the flet page. This was not in line with email formatting, looked bad, and users were unable to copy into a email client. 

New flow: user clicks generate and a new window opens with the html formatted contents. This is in line with how the email newsletter looks, looks good, and users are able to copy and paste (with html rendered) into their email clients. 

Note: Made some changes to how db_service works. You can now specify N number of days back via get_documents for past n days allowing us to allow users to go back however many days they want. 
The way things currently work (previous to this PR) is that recommendations are created per day granularity. This means users are unable to get top 3 recommendations across the week. Instead they get top 3 per day. We should probably change this in the future because it's more useful for the user to get recs across a large time span. However, this probably requires a change in the way we store things. 