### PR TITLE
Tempfile -> GCS files and Signed URLs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,18 @@
 import flet as ft
-import tempfile
-import os
+import os, requests, datetime
+from google.cloud import storage
 import newsletter_service, db_service
+import google.auth.transport.requests
+from google.auth import impersonated_credentials
 
 USER_PERSONA = db_service.get_components_from_firestore(
     'gcp_newsletter', 'settings')['settings']['persona']
 USER_TOPIC = db_service.get_components_from_firestore(
     'gcp_newsletter', 'settings')['settings']['topic']
 TIME_PERIOD = ["day", "week"]
+
+PROJECT_ID = "project-ana-851024"
+HTML_GCS_BUCKET = "rendered-newsletter-html-files"
 
 # Define the RSS feed URL - "https://blog.google/products/google-cloud/rss/"
 rss_url = "https://snownews.appspot.com/feed"
@@ -17,8 +22,70 @@ sender_password = os.environ.get(
     "SENDER_PASSWORD"
 )  # Make gmail app password from here:https://support.google.com/accounts/answer/185833?visit_id=638655613103411169-2477840836&p=InvalidSecondFactor&rd=1
 
+# Define storage client for file uploads
+storage_client = storage.Client(project=PROJECT_ID)
+
+
+def getCreds():
+    creds, _ = google.auth.default(
+        scopes=['https://www.googleapis.com/auth/cloud-platform'])
+    auth_req = google.auth.transport.requests.Request()
+    creds.refresh(auth_req)
+    return creds
+
+
+# Function to get signed GCS urls
+def getSignedURL(filename, bucket, action):
+
+    # creds = service_account.Credentials.from_service_account_file('./credentials.json')
+    creds = getCreds()
+
+    signing_credentials = impersonated_credentials.Credentials(
+        source_credentials=creds,
+        target_principal='526257981680-compute@developer.gserviceaccount.com',
+        target_scopes='',
+        lifetime=500)
+
+    blob = bucket.blob(filename)
+
+    url = blob.generate_signed_url(expiration=datetime.timedelta(minutes=60),
+                                   method=action,
+                                   credentials=signing_credentials,
+                                   version="v4")
+    return url
+
+
+# Function to upload bytes object to GCS bucket
+def upload_file(uploaded_file_contents, uploaded_file_name, bucket_name, type):
+
+    bucket = storage_client.bucket(bucket_name)
+
+    url = getSignedURL(uploaded_file_name, bucket, "PUT")
+    # blob.upload_from_string(uploaded_file.read())
+
+    print(f"Upload Signed URL: {url}")
+
+    # encoded_content = base64.b64encode(uploaded_file.read()).decode("utf-8")
+
+    # Again leverage signed URLs here to circumvence Cloud Run's 32 MB upload limit
+    response = requests.put(url,
+                            uploaded_file_contents,
+                            headers={'Content-Type': type})
+
+    #TODO: review. Returns unsuccessful upon success.
+    print(response.status_code)
+    print(response.reason)
+    output = f"Error in uploading content: {response.status_code} {response.reason} {response.text}"
+    if response.status_code == 200:
+        output = "Success"
+    return output
+
 
 def main(page: ft.Page):
+    signed_url = "error"  # Replace with error page url
+
+    def open_newsletter_clicked(e, signed_url):
+        page.launch_url(signed_url)
 
     def button_clicked(e):
         loading = ft.Text(
@@ -26,7 +93,7 @@ def main(page: ft.Page):
         )
         page.add(loading)
         # Call newsletter_service.py to Generate Newsletter, pass values along
-        newsletter = newsletter_service.generate_newsletter_from_db(
+        newsletter_value = newsletter_service.generate_newsletter_from_db(
             time_period=time_period.value,
             user_persona=persona.value,
             user_topic=topic.value,
@@ -42,17 +109,28 @@ def main(page: ft.Page):
         #     ),
         #     expand=True,  # Allow the container to take up available space
         # )
+
         # Create html formatted email
-        with tempfile.NamedTemporaryFile(mode="w",
-                                         delete=False,
-                                         dir="/tmp",
-                                         suffix=".html") as f:
-            f.write(newsletter)
-            temp_file_path = f.name
-        file_url = f"file://{temp_file_path}"
-        page.launch_url(url=file_url)
+        newsletter_name = f"{persona.value}_{topic.value}_{datetime.date.today()}.html"
+        # Write newsletter to GCS
+        result = upload_file(uploaded_file_contents=newsletter_value,
+                             uploaded_file_name=newsletter_name,
+                             bucket_name=HTML_GCS_BUCKET,
+                             type="text/html")
+        print(f"File upload result: {result}")
+        # Get signed url for said GCS file
+        signed_url = getSignedURL(
+            newsletter_name,
+            storage_client.bucket("rendered-newsletter-html-files"), "GET")
+        print(signed_url)
+        # Display link to open GCS file
+        page.add(
+            ft.TextButton(
+                f"Click here to open generated newsletter: {newsletter_name}",
+                on_click=lambda e: open_newsletter_clicked(e, signed_url)))
+        # page.add(ft.Text(signed_url, selectable=True))
         # page.add(newsletter_container)  # Add the container to the page
-        page.update()
+
 
     p = ft.Text()
     b = ft.ElevatedButton(text="Generate", on_click=button_clicked)


### PR DESCRIPTION
Changed to use GCS and Signed URLs instead of tempfile. Tempfile is really not the best here because it stores the files in /private/ directory. I could have switched to storing the files in Cloud Run tmp/ directory which is writable to us, but it's probably not the best long term solution because the memory in cloud run is expensive whereas the memory in cloud storage is cheap. Also signed urls are generally the best practice. This works in my local environment but I have not pushed to deployments yet. 